### PR TITLE
Fix handle quotes in template

### DIFF
--- a/lustache.lua
+++ b/lustache.lua
@@ -45,8 +45,8 @@ is_array = function(array)
   return n == max
 end
 
-quote = function(string)
-  return '"'..string..'"'
+quote = function(str)
+  return '"'..string.gsub(str, "\"","\\\"")..'"'
 end
 
 escape_html = function(string)

--- a/spec/parse_spec.lua
+++ b/spec/parse_spec.lua
@@ -79,7 +79,12 @@ expectations = {
   { template = "{{=<% %>=}}<%hi%>", value                       = { { type= "=", value= "<% %>" }, { type= "name", value= "hi" } }},
   { template = "{{#a}}{{/a}}hi{{#b}}{{/b}}\n", value            = { { type= "#", value= "a", tokens= {} }, { type= "text", value= "hi" }, { type= "#", value= "b", tokens= {} }, { type= "text", value= "\\n" } }},
   { template = "{{a}}\n{{b}}\n\n{{#c}}{{/c}}", value        = { { type= "name", value= "a" }, { type= "text", value= "\\n" }, { type= "name", value= "b" }, { type= "text", value= "\\n\\n" }, { type= "#", value= "c", tokens= {} } }},
-  { template = "{{#foo}}{{#a}}    {{b}}  {{/a}}{{/foo}}", value = { { type = "#", value = "foo", tokens = { { type = "#", value = "a", tokens = { { type = "text", value = "    " }, { type = "name", value = "b" }, { type = "text", value = "  " } } } } } }}
+  { template = "{{#foo}}{{#a}}    {{b}}  {{/a}}{{/foo}}", value = { { type = "#", value = "foo", tokens = { { type = "#", value = "a", tokens = { { type = "text", value = "    " }, { type = "name", value = "b" }, { type = "text", value = "  " } } } } } }},
+
+  { template = "a", value                                = { { type= "text", value= "a" } }},
+  { template = "\"", value                                = { { type= "text", value= "\"" } }},
+  { template = "\"a\"", value                                = { { type= "text", value= "\"a\"" } }},
+  { template = "\"{{a}}\"", value                                = { { type= "text", value= "\"" }, { type="name", value="a" }, { type="text", value="\""} }},
 }
 
 function setup()

--- a/spec/render_spec.lua
+++ b/spec/render_spec.lua
@@ -28,6 +28,25 @@ function RenderTextTest()
   assert_equal(expectation, lustache.render(template, data, partials))
 end
 
+function RenderQuoteTest()
+  template = "\""
+  expectation = "\""
+  assert_equal(expectation, lustache.render(template, data, partials))
+end
+
+function RenderMixedQuoteTest()
+  template = "\"'\""
+  expectation = "\"'\""
+  assert_equal(expectation, lustache.render(template, data, partials))
+end
+
+function RenderQuotedDataTest()
+  template = "\"{{message}}\""
+  expectation = '"Hi"'
+  data = { message = "Hi" }
+  assert_equal(expectation, lustache.render(template, data, partials))
+end
+
 function RenderDataTest()
   template = "{{ message }}"
   expectation = "Hi"


### PR DESCRIPTION
While there are qoutes in template, I'll get error: 

```
/usr/bin/lua: ./lustache.lua:333: attempt to call a nil value
stack traceback:
    ./lustache.lua:333: in function 'compile_tokens'
    ./lustache.lua:197: in function 'compile'
    ./lustache.lua:214: in function <./lustache.lua:210>
(tail call): ?
    ./tpl:122: in main chunk
[C]: ?
```

this simple fix handle function quote() to escape qoutes in string. (There is also few additional test in spec)
