### PR TITLE
Added: Runtime/delayed compile for partials.

### DIFF
--- a/src/lustache.lua
+++ b/src/lustache.lua
@@ -21,6 +21,7 @@ return setmetatable(lustache, {
     if self.renderer[idx] then return self.renderer[idx] end
   end,
   __newindex = function(self, idx, val)
+    if idx == "partials" then self.renderer.partials = val end
     if idx == "tags" then self.renderer.tags = val end
   end
 })


### PR DESCRIPTION
Oh hai!

I needed a solution to avoid knowing all the partials in runtime. It should not break anything, but add the possibility to provide a partials-table with a custom metatable, overwriting its __index field. Like this:

``` lua
local partials_lut = {}
local mt = { 
    __index = function ( self, needed_partial )

      -- do stuff here that cant be done
      --  before running lustache.render
      return do_some_cool_stuff( needed_partial )

    end}
setmetatable(partials_lut, mt)

local template = ...
local view = ...

lustache:render(template, view, partials_lut)
```

I use it in a static site generation project I'm writing in Lua, much like how Jekyll work. I recursively "compile" the files I need, and thus I can't know beforehand if a mustache template will need a specific partial. Instead I "compile" needed partial only if it requested via the __index-field.

Perhaps others might benefit from this functionality as well! :)

Regards,
Sven
