### PR TITLE
Support explicit conditional blocks

### DIFF
--- a/src/lustache/renderer.lua
+++ b/src/lustache/renderer.lua
@@ -12,7 +12,7 @@ local patterns = {
   nonSpace = "%S",
   eq = "%s*=",
   curly = "%s*}",
-  tag = "[#\\^/>{&=!]"
+  tag = "[#\\^/>{&=!?]"
 }
 
 local html_escape_characters = {
@@ -27,6 +27,7 @@ local html_escape_characters = {
 local block_tags = {
   ["#"] = true,
   ["^"] = true,
+  ["?"] = true,
 }
 
 local function is_array(array)
@@ -63,6 +64,9 @@ local function compile_tokens(tokens, originalTemplate)
     for i, token in ipairs(tokens) do
       local t = token.type
       buf[#buf+1] = 
+        t == "?" and rnd:_conditional(
+          token, ctx, subrender(i, token.tokens)
+        ) or
         t == "#" and rnd:_section(
           token, ctx, subrender(i, token.tokens), originalTemplate
         ) or
@@ -206,6 +210,16 @@ function renderer:render(template, view, partials)
   end
 
   return fn(view)
+end
+
+function renderer:_conditional(token, context, callback)
+  local value = context:lookup(token.value)
+
+  if value then
+    return callback(context, self)
+  end
+
+  return ""
 end
 
 function renderer:_section(token, context, callback, originalTemplate)

--- a/src/lustache/renderer.lua
+++ b/src/lustache/renderer.lua
@@ -24,6 +24,11 @@ local html_escape_characters = {
   ["/"] = "&#x2F;"
 }
 
+local block_tags = {
+  ["#"] = true,
+  ["^"] = true,
+}
+
 local function is_array(array)
   if type(array) ~= "table" then return false end
   local max, n = 0, 0
@@ -89,7 +94,7 @@ local function nest_tokens(tokens)
   local token, section
 
   for i,token in ipairs(tokens) do
-    if token.type == "#" or token.type == "^" then
+    if block_tags[token.type] then
       token.tokens = {}
       sections[#sections+1] = token
       collector[#collector+1] = token


### PR DESCRIPTION
Explicit conditional blocks are e.g. necessary to support introducing the
 expansion of a list with an optional header, like in the following example:

```mustache
{{?products}}
Product names:
  {{#products}}
  - {{name}}
  {{/products}}
{{/products}}
{{^products}}
No products
{{/products}}
```

I did not include tests, because their data is included in the corresponding
 pull request to the Mustache spec.

This uses the flexible block-tag checks from #27.

See-Also: https://github.com/mustache/spec/pull/22
See-Also: https://github.com/mustache/spec/issues/55#issuecomment-9936333