### PR TITLE
Fix partials containing lambdas

### DIFF
--- a/src/lustache/renderer.lua
+++ b/src/lustache/renderer.lua
@@ -261,7 +261,7 @@ function renderer:_partial(name, context, originalTemplate)
     end
     
     -- compile partial and store result in cache
-    fn = self:compile(partial, nil, originalTemplate)
+    fn = self:compile(partial, nil, partial)
     self.partial_cache[name] = fn
   end
   return fn and fn(context, self) or ""


### PR DESCRIPTION
If a partial contained a lambda, that lambda would see the text of the parent
 template (i.e. the one containing the partial) instead of its own template
 (i.e. the text of the partial).