### PR TITLE
fix: when value is false, judge error

### DIFF
--- a/src/lustache/context.lua
+++ b/src/lustache/context.lua
@@ -40,7 +40,7 @@ function context:lookup(name)
           value = context.view[name]
         end
 
-        if value then
+        if value ~= nil then
           break
         end
 


### PR DESCRIPTION
This judgment is to confirm whether the "value" has a valid value, but when the content of the "value" is the bool value "false", this judgment cannot meet the design intent